### PR TITLE
Send id in subscribe packets

### DIFF
--- a/src/mqtt_crystal/client.cr
+++ b/src/mqtt_crystal/client.cr
@@ -68,7 +68,7 @@ class MqttCrystal::Client
   end
 
   def subscribe(topics : Array(String)) : self
-    topics.each { |topic| send Packet::Subscribe.new(topic: topic) }
+    topics.each { |topic| send Packet::Subscribe.new(id: next_packet_id, topic: topic) }
 
     self
   end


### PR DESCRIPTION
Without an ID, some brokers do not accept the subscribe request and terminate the connection instead.

Observed this in mosquitto. Without this patch, the included get.cr example will keep printing "Exception: read failed" when using a mosquitto broker instance.