### PR TITLE
Connect before publishing

### DIFF
--- a/src/mqtt_crystal/client.cr
+++ b/src/mqtt_crystal/client.cr
@@ -133,6 +133,7 @@ class MqttCrystal::Client
   end
 
   def publish(topic : String, payload : String)
+    connect unless @connected
     send Packet::Publish.new(id: next_packet_id, qos: 1_u8, topic: topic, payload: payload)
   end
 


### PR DESCRIPTION
Following the pattern in get, this ensures that at least a connection attempt is started when you first publish