### PR TITLE
Fix Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: crystal
 script:
   - crystal spec

--- a/spec/mqtt_crystal_spec.cr
+++ b/spec/mqtt_crystal_spec.cr
@@ -449,10 +449,10 @@ describe MqttCrystal do
     spawn {
       sleep (subscribed_max_wait * subscribed_wait_count +
              publish_max_wait * publish_count * 7 + 2000).milliseconds
-      it "wait too long" {
-        client.close
-        false.should eq true
-      }
+      client.close
+      done.send true
+      config.delete
+      fail "waited too long"
     }
 
     get_count = 0

--- a/spec/mqtt_crystal_spec.cr
+++ b/spec/mqtt_crystal_spec.cr
@@ -421,7 +421,10 @@ describe MqttCrystal do
         ready.send true
         # Cleanup mosquitto after test finishes
         done.receive
-        p.kill
+        begin
+          p.kill
+        rescue
+        end
       }
     end
 


### PR DESCRIPTION
The default image for Travis has a version of mosquitto that's too old (0.15, vs. current is 1.6.3), so it does not start up with the same config file.

Upgrading Travis to Xenial fixes the CI build. Also made some other improvements to the tests.

You can see an example passing build here: https://travis-ci.org/soumya92/mqtt_crystal/builds/550626272.