### PR TITLE
[breaking] Use Blocking API for messages

### DIFF
--- a/examples/get.cr
+++ b/examples/get.cr
@@ -1,3 +1,4 @@
 require "../src/mqtt_crystal"
 
-MqttCrystal::Client.new(host: "172.17.0.1").get("pub/#") { |t, m| puts "#{t}, #{m}" }
+t, m = MqttCrystal::Client.new(host: "172.17.0.1").subscribe("pub/#").receive
+puts "#{t}, #{m}"

--- a/examples/receive.cr
+++ b/examples/receive.cr
@@ -3,18 +3,15 @@ require "../src/mqtt_crystal"
 
 module Mqttdemo
   client = MqttCrystal::Client.new(id: UUID.random.to_s,
-                                   host: "172.17.0.1",
-                                   port: 1883_u16,
-                                   username: "liuchong",
-                                   password: "xxxxxx")
+    host: "172.17.0.1",
+    port: 1883_u16,
+    username: "liuchong",
+    password: "xxxxxx")
 
   spawn {
     loop do
-      pp packet = client.channel.receive
-      if packet.is_a?(MqttCrystal::Packet::Publish)
-        packet = packet.as(MqttCrystal::Packet::Publish)
-        client.socket.write MqttCrystal::Packet::Puback.new(id: packet.id).bytes if packet.qos > 0
-      end
+      topic, msg = client.receive
+      puts "#{topic} = #{msg}"
     end
   }
 

--- a/examples/verify_test_get.cr
+++ b/examples/verify_test_get.cr
@@ -6,11 +6,14 @@ get_count, err_count = 0, 0
 spawn {
   loop do
     sleep 1
-    puts "get_count, err_count: #{[ get_count, err_count ]}"
+    puts "get_count, err_count: #{[get_count, err_count]}"
   end
 }
 
-MqttCrystal::Client.new(host: "iot.liuchong.me").get("lccc/verify/test/#") { |t, m|
+client = MqttCrystal::Client.new(host: "iot.liuchong.me")
+client.subscribe("lccc/verify/test/#")
+loop {
+  t, m = client.receive
   get_count += 1
   err_count += 1 if OpenSSL::MD5.hash(t).map { |c| "%02x" % c }.join != m
 }

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,3 +8,34 @@ def slice_it(a : String) : Bytes
   bytes.map_with_index { |b, i| slice[i] = b }
   slice
 end
+
+def with_mosquitto
+  config = File.tempfile("mosquitto.conf")
+  config << "port 1883"
+  config << "allow_anonymous true"
+
+  ready = Channel(Bool).new
+  done = Channel(Bool).new
+  spawn do
+    Process.run("mosquitto", ["-c", config.path], input: Process::Redirect::Close) { |p|
+      loop {
+        break if p.error.read_line.includes? "on port 1883"
+      }
+      ready.send true
+      # Cleanup mosquitto after test finishes
+      done.receive
+      begin
+        p.kill
+      rescue
+      end
+    }
+  end
+
+  ready.receive
+  begin
+    yield
+  ensure
+    done.send true
+    config.delete
+  end
+end


### PR DESCRIPTION
It's easy to convert blocking API to non-blocking via spawn and channels, but it's much harder to convert a callback-based API to be blocking, and since crystal makes it easy to avoid callback hell, providing a blocking API is the most flexible option.

See also comments on the crystal-lang websocket API: https://github.com/crystal-lang/crystal/issues/5600#issuecomment-402553447

Fixes #15.

This is a breaking change, since the API is now completely different.