### PR TITLE
Close client on disconnection if auto-reconnect is disabled

### DIFF
--- a/src/mqtt_crystal/client.cr
+++ b/src/mqtt_crystal/client.cr
@@ -152,7 +152,10 @@ class MqttCrystal::Client
   end
 
   private def reconnect : self
-    return self if !@auto_reconnect
+    unless @auto_reconnect
+      close
+      return self
+    end
     @connecting = @connected = false
     @subscribed.clear
     begin

--- a/src/mqtt_crystal/packet.cr
+++ b/src/mqtt_crystal/packet.cr
@@ -458,22 +458,23 @@ class MqttCrystal::Packet
     include PacketWithNoPayload
   end
 
-  PACKET_TYPES = [nil,
-                  Packet::Connect,
-                  Packet::Connack,
-                  Packet::Publish,
-                  Packet::Puback,
-                  Packet::Pubrec,
-                  Packet::Pubrel,
-                  Packet::Pubcomp,
-                  Packet::Subscribe,
-                  Packet::Suback,
-                  Packet::Unsubscribe,
-                  Packet::Unsuback,
-                  Packet::Pingreq,
-                  Packet::Pingresp,
-                  Packet::Disconnect,
-                  nil,
+  PACKET_TYPES = [
+    nil,
+    Packet::Connect,
+    Packet::Connack,
+    Packet::Publish,
+    Packet::Puback,
+    Packet::Pubrec,
+    Packet::Pubrel,
+    Packet::Pubcomp,
+    Packet::Subscribe,
+    Packet::Suback,
+    Packet::Unsubscribe,
+    Packet::Unsuback,
+    Packet::Pingreq,
+    Packet::Pingresp,
+    Packet::Disconnect,
+    nil,
   ]
 
   enum ConnackResponse : UInt8


### PR DESCRIPTION
This ensures that failures propagate to the caller so that caller can handle it appropriately. Otherwise the connection can just hang in the disconnected state forever.